### PR TITLE
Replace flint with gravel instead of adding gravel

### DIFF
--- a/src/main/java/iguanaman/iguanatweakstconstruct/tweaks/handlers/FlintHandler.java
+++ b/src/main/java/iguanaman/iguanatweakstconstruct/tweaks/handlers/FlintHandler.java
@@ -18,14 +18,16 @@ public class FlintHandler {
         if(event.block != null && event.block == Blocks.gravel)
         {
             ListIterator<ItemStack> iter = event.drops.listIterator();
-            boolean hasGravel = false;
+            boolean hasGravel = true;
             while(iter.hasNext())
             {
                 Item item = iter.next().getItem();
                 if(item == Items.flint)
+                {
                     iter.remove();
-                else if(item == Item.getItemFromBlock(Blocks.gravel))
-                    hasGravel = true;
+                    hasGravel = false;
+                    break;
+                }
             }
 
             // ensure that gravel drops


### PR DESCRIPTION
Prevents conflicts with other mods that would edit drops in the same event, if the other event happens to fire first.